### PR TITLE
Buttons in cockpit are not working

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-clamscan-freshclam-update
+++ b/root/etc/e-smith/events/actions/nethserver-clamscan-freshclam-update
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 /usr/bin/rm -rf /var/lib/clamav/*
-/usr/bin/systemctl start freshclam-nethgui.service
+/usr/share/clamav/freshclam-sleep xnow;/usr/bin/clamav-unofficial-sigs.sh

--- a/root/etc/e-smith/events/actions/nethserver-clamscan-now
+++ b/root/etc/e-smith/events/actions/nethserver-clamscan-now
@@ -1,1 +1,1 @@
-/usr/bin/systemctl start clamscan-nethgui.service
+/sbin/e-smith/nethserver-clamscan

--- a/root/lib/systemd/system/clamscan-nethgui.service
+++ b/root/lib/systemd/system/clamscan-nethgui.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Start a scan in nethgui
-Requisite=httpd-admin.service
-
-[Service]
-Type=simple
-ExecStart=/sbin/e-smith/nethserver-clamscan

--- a/root/lib/systemd/system/freshclam-nethgui.service
+++ b/root/lib/systemd/system/freshclam-nethgui.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Freshclam Update  in nethgui
-Requisite=httpd-admin.service
-
-[Service]
-Type=simple
-ExecStart=/usr/share/clamav/freshclam-sleep xnow;/usr/bin/clamav-unofficial-sigs.sh


### PR DESCRIPTION
Hi @stephdl 

Root cause is the optional installation of nethserver-httpd-admin which provides the httpd-admin.service which is still a Requisite  to run` Scan now` and `Update the database` 

**ALSO SEE**
https://community.nethserver.org/t/clamscan-error-the-scan-is-not-started/17740
